### PR TITLE
fixed missing opentracing-go package dependencies

### DIFF
--- a/observer.go
+++ b/observer.go
@@ -13,6 +13,7 @@ import opentracing "github.com/opentracing/opentracing-go"
 //
 type Observer interface {
 	// Create and return a span observer. Called when a span starts.
+	// If the Observer is not interested in the given span, it must return (nil, false).
 	// E.g :
 	//     func StartSpan(opName string, opts ...opentracing.StartSpanOption) {
 	//         var sp opentracing.Span

--- a/observer.go
+++ b/observer.go
@@ -15,12 +15,18 @@ type Observer interface {
 	// Create and return a span observer. Called when a span starts.
 	// E.g :
 	//     func StartSpan(opName string, opts ...opentracing.StartSpanOption) {
-	//     var sp opentracing.Span
-	//     sso := opentracing.StartSpanOptions{}
-	//     var spObs otobserver.SpanObserver = observer.OnStartSpan(span, opName, sso)
-	//     ...
-	// }
-	OnStartSpan(sp opentracing.Span, operationName string, options opentracing.StartSpanOptions) SpanObserver
+	//         var sp opentracing.Span
+	//         sso := opentracing.StartSpanOptions{}
+	//         var (
+	//             spObs otobserver.SpanObserver
+	//             ok    bool
+	//         )
+	//         if spObs, ok = observer.OnStartSpan(span, opName, sso); ok {
+	//             // we have a valid span observer
+	//         }
+	//         ...
+	//     }
+	OnStartSpan(sp opentracing.Span, operationName string, options opentracing.StartSpanOptions) (SpanObserver, bool)
 }
 
 // SpanObserver is created by the Observer and receives notifications about

--- a/observer.go
+++ b/observer.go
@@ -18,12 +18,9 @@ type Observer interface {
 	//     func StartSpan(opName string, opts ...opentracing.StartSpanOption) {
 	//         var sp opentracing.Span
 	//         sso := opentracing.StartSpanOptions{}
-	//         var (
-	//             spObs otobserver.SpanObserver
-	//             ok    bool
-	//         )
-	//         if spObs, ok = observer.OnStartSpan(span, opName, sso); ok {
-	//             // we have a valid span observer
+	//         spanObserver, ok := observer.OnStartSpan(span, opName, sso);
+	//         if ok {
+	//             // we have a valid SpanObserver
 	//         }
 	//         ...
 	//     }

--- a/observer.go
+++ b/observer.go
@@ -2,6 +2,8 @@
 
 package otobserver
 
+import opentracing "github.com/opentracing/opentracing-go"
+
 // Observer can be registered with a Tracer to recieve notifications
 // about new Spans. Tracers are not required to support the Observer API.
 // The actual registration depends on the implementation, which might look
@@ -18,7 +20,7 @@ type Observer interface {
 	//     var spObs otobserver.SpanObserver = observer.OnStartSpan(span, opName, sso)
 	//     ...
 	// }
-	OnStartSpan(sp Span, operationName string, options StartSpanOptions) SpanObserver
+	OnStartSpan(sp opentracing.Span, operationName string, options opentracing.StartSpanOptions) SpanObserver
 }
 
 // SpanObserver is created by the Observer and receives notifications about
@@ -29,5 +31,5 @@ type SpanObserver interface {
 	// Callback called from opentracing.Span.SetTag()
 	OnSetTag(key string, value interface{})
 	// Callback called from opentracing.Span.Finish()
-	OnFinish(options FinishOptions)
+	OnFinish(options opentracing.FinishOptions)
 }


### PR DESCRIPTION
with this change there would be no need to declare the interface in opentracing go implementations but directly reference this package.